### PR TITLE
feat: Add Docker Compose and import script for local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,40 +17,53 @@ A production-ready, open-source API for Philippine government budget transparenc
 - ✅ **REST API**: Clean, well-documented endpoints
 - ✅ **TypeScript**: Full type safety and IDE support
 
-## 🚀 Quick Start
+## 🚀 Quick Start (with Docker)
+
+This project includes a fully automated setup using Docker and a custom import script, which is the recommended way to get started.
 
 ### Prerequisites
 
+- **Docker** & **Docker Compose**
 - **Node.js** 20+
-- **Neo4j Database** 5.x with BetterGovPH budget data loaded
 - **Yarn** package manager
+- **Bash** (for the import script)
 
-> **Note**: The Neo4j database must be pre-populated with budget data from the [open-budget-data](https://github.com/bettergovph/open-budget-data) repository. See [Data Source](#-data-source) section below.
-
-### Installation
+### 1. Clone and Configure
 
 ```bash
 # Clone the repository
 git clone https://github.com/bettergovph/open-budget-api.git
 cd open-budget-api
 
-# Install dependencies
-yarn install
-
-# Configure environment
+# Create your environment file
 cp .env.example .env
-# Edit .env with your Neo4j credentials and configuration
+# The default .env values are pre-configured for the Docker setup.
 ```
 
-### Running the Application
+### 2. Start Database & Import Data
+
+This step will start a Neo4j container and then populate it with over 6.8 million budget records.
+
+```bash
+# Start the Neo4j database in the background
+docker-compose up -d
+
+# Make the import script executable
+chmod +x import-budget-data.sh
+
+# Run the import script
+# This will clone the data repository, convert files, and load them into Neo4j.
+# Note: This process will take several minutes to complete.
+./import-budget-data.sh
+```
+
+### 3. Run the Application
+
+Once the data import is complete, you can start the API server.
 
 ```bash
 # Development mode (with hot reload)
 yarn start:dev
-
-# Production mode
-yarn build
-yarn start:prod
 ```
 
 ### Access the API
@@ -280,15 +293,13 @@ The [open-budget-data](https://github.com/bettergovph/open-budget-data) reposito
 - UACS dimension mappings (departments, agencies, expense classifications, etc.)
 - Data validation and processing tools
 
-### Setting Up the Database
+### Setting Up the Database (Automated)
 
-To use this API, you need to first populate your Neo4j database with the budget data:
+The process of setting up the Neo4j database and importing the data is **fully automated**.
 
-1. Clone the [open-budget-data](https://github.com/bettergovph/open-budget-data) repository
-2. Follow the setup instructions to import data into Neo4j
-3. Configure this API to connect to your populated Neo4j instance
+The `docker-compose.yml` file starts a pre-configured Neo4j instance, and the `import-budget-data.sh` script handles the entire data pipeline, from cloning the source data to populating the database.
 
-See the [open-budget-data README](https://github.com/bettergovph/open-budget-data#readme) for detailed setup instructions.
+**Please follow the instructions in the [🚀 Quick Start](#-quick-start-with-docker) section for a one-time, automated setup.**
 
 ## 🛣️ Roadmap
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  neo4j:
+    image: neo4j:5
+    container_name: open-budget-api-neo4j
+    ports:
+      - "7474:7474" # HTTP
+      - "7687:7687" # Bolt
+    volumes:
+      - neo4j_data:/data
+    environment:
+      # Set the password for the neo4j user
+      - NEO4J_AUTH=neo4j/password
+
+volumes:
+  neo4j_data:

--- a/import-budget-data.sh
+++ b/import-budget-data.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+echo "Starting budget data import process..."
+
+# --- Configuration ---
+# Assuming Neo4j is running locally via Docker Compose on default ports
+# and credentials are set in the .env file of the open-budget-api project.
+# We will pass these to the data importer's .env file.
+
+# Check if .env exists in the current directory (open-budget-api project)
+if [ ! -f .env ]; then
+    echo "Error: .env file not found in the current directory. Please create it based on .env.example."
+    exit 1
+fi
+
+# Load Neo4j credentials from the current project's .env file
+source .env
+
+NEO4J_URI=${NEO4J_URI:-"neo4j://localhost:7687"}
+NEO4J_USER=${NEO4J_USER:-"neo4j"}
+NEO4J_PASSWORD=${NEO4J_PASSWORD:-"password"}
+
+# --- Clone and Prepare Data Importer Repository ---
+DATA_IMPORTER_DIR="../data-importer"
+OPEN_BUDGET_DATA_REPO="https://github.com/bettergovph/open-budget-data.git"
+
+if [ ! -d "$DATA_IMPORTER_DIR" ]; then
+    echo "Cloning open-budget-data repository into $DATA_IMPORTER_DIR..."
+    git clone "$OPEN_BUDGET_DATA_REPO" "$DATA_IMPORTER_DIR"
+else
+    echo "open-budget-data repository already exists. Pulling latest changes..."
+    (cd "$DATA_IMPORTER_DIR" && git pull)
+fi
+
+echo "Navigating to data importer directory: $DATA_IMPORTER_DIR"
+cd "$DATA_IMPORTER_DIR"
+
+# --- Setup Python Environment ---
+echo "Setting up Python virtual environment and installing dependencies..."
+python3 -m venv venv
+source venv/bin/activate
+
+# Always recreate requirements.txt to ensure it's up-to-date
+echo "Creating/updating requirements.txt with known dependencies (neo4j, pandas, openpyxl, requests)."
+cat << EOF_REQ > requirements.txt
+neo4j
+pandas
+openpyxl
+requests
+EOF_REQ
+
+pip install --upgrade pip # Ensure pip is up-to-date
+pip install -r requirements.txt
+
+# --- Create .env for Data Importer ---
+echo "Creating .env file for data importer with Neo4j credentials..."
+cat << EOF > .env
+NEO4J_URI=$NEO4J_URI
+NEO4J_USER=$NEO4J_USER
+NEO4J_PASSWORD=$NEO4J_PASSWORD
+EOF
+
+# --- Data Conversion ---
+echo "Starting UACS data conversion..."
+UACS_TYPES=("funding-source" "location" "mfo-pap" "object-code" "organization")
+for UACS_TYPE in "${UACS_TYPES[@]}"; do
+    UACS_SCRIPT=""
+    if [ "$UACS_TYPE" == "object-code" ]; then
+        UACS_SCRIPT="scripts/uacs/${UACS_TYPE}/analyze.py" # Specific for object-code
+    else
+        UACS_SCRIPT="scripts/uacs/${UACS_TYPE}/converter.py" # Default for others
+    fi
+
+    if [ ! -f "$UACS_SCRIPT" ]; then
+        echo "Error: UACS converter script not found for $UACS_TYPE at $UACS_SCRIPT."
+        echo "Please verify the structure of the open-budget-data repository."
+        exit 1
+    fi
+    echo "  Converting UACS type: $UACS_TYPE"
+    python3 "$UACS_SCRIPT"
+done
+
+NEP_GAA_CONVERTER_SCRIPT="scripts/nep-gaa/converter.py"
+SYNC_SCRIPT="sync.py"
+
+# Check if NEP/GAA converter script exists
+if [ ! -f "$NEP_GAA_CONVERTER_SCRIPT" ]; then
+    echo "Error: NEP/GAA converter script not found at $NEP_GAA_CONVERTER_SCRIPT."
+    echo "Please verify the structure of the open-budget-data repository."
+    exit 1
+fi
+
+echo "Starting NEP/GAA budget data conversion..."
+python3 "$NEP_GAA_CONVERTER_SCRIPT"
+
+# Check if sync script exists
+if [ ! -f "$SYNC_SCRIPT" ]; then
+    echo "Error: Sync script not found at $SYNC_SCRIPT."
+    echo "Please verify the structure of the open-budget-data repository."
+    exit 1
+fi
+
+echo "Waiting for Neo4j to be fully ready before syncing..."
+sleep 10 # Give Neo4j a bit more time after conversions
+
+echo "Syncing all converted data to Neo4j..."
+# Explicitly pass Neo4j credentials as environment variables
+NEO4J_URI=$NEO4J_URI \
+NEO4J_USER=$NEO4J_USER \
+NEO4J_PASSWORD=$NEO4J_PASSWORD \
+python3 "$SYNC_SCRIPT"
+
+echo "Budget data import complete!"
+
+# --- Cleanup ---
+deactivate
+echo "Deactivated Python virtual environment."
+echo "You can now return to the open-budget-api project directory."


### PR DESCRIPTION
### Description

This pull request introduces two key files to streamline the local development setup process:

1. `docker-compose.yml`: A Docker Compose file to easily spin up a pre-configured Neo4j 5 database instance.
2. `import-budget-data.sh`: An automated script that handles the entire process of fetching, converting, and importing the necessary budget data into the Neo4j database.

### Justification

The current process for setting up a local development environment is manual, time-consuming, and can be a significant barrier for new contributors. It requires developers to:

- Manually install and configure a Neo4j database.
- Separately clone the open-budget-data repository.
- Set up a Python environment with the correct dependencies.
- Run multiple data conversion and import scripts in the correct sequence.

These new files automate the entire workflow, providing a consistent and reproducible development environment. By simplifying the setup from a multi-step manual process to a few simple commands, we can significantly lower the barrier to entry for new contributors and accelerate onboarding.

### How to Use This Setup

1. Ensure Docker is running.
2. Set up environment variables:
   ```
   cp .env.example .env
   ```
3. Start the Neo4j database:
   ```
   docker-compose up -d
   ```
4. Run the import script:
   ```
   chmod +x import-budget-data.sh
   ./import-budget-data.sh
   ```
5. Run the API development server:
   ```
   yarn start:dev
   ```